### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "inherit": "~2.2.2",
     "js-yaml": "~3.3.1",
     "lodash.defaults": "~3.1.1",
-    "request": "~2.57.0",
+    "request": "~2.74.0",
     "router-base": "^1.0.0",
     "sibling": "^0.1.3",
     "tough-cookie": "~2.2.2",


### PR DESCRIPTION
bnsf currently has a 19 vulnerable dependency paths, introducing 7 different types of known vulnerabilities.

This PR fixes  vulnerable dependencies, [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/apsavin/bnsf) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)